### PR TITLE
fix: missing csv uri and lint

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -24,7 +24,7 @@ function _get_code_list() {
     }' y="$year"
 }
 
-# Download stdin urls to a spesific dir
+# Download pages of urls given from stdin urls to a spesific dir
 function _download() {
   local url class_code
 


### PR DESCRIPTION
https://github.com/Make-IT-TSUKUBA/alternative-tsukuba-kdb/commit/07a532dee10497a8f43f4ddf66e398ea0a4a7f66 でCSVパスが変更されたのに対応しました。また可読性を高めるなどしました。