### PR TITLE
fix: workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        # with:
-        #   token: ${{ secrets.GH_ADMIN_TOKEN }}
+        with:
+          ref: gh-pages
       - name: Run download script
         run: |
+          wget -O download.sh https://git.io/JinJf
+          chmod +x download.sh
           ./download.sh
       - name: Get current date
         id: date
@@ -25,7 +27,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          # token: ${{ secrets.GH_ADMIN_TOKEN }}
           title: Sceduled update of syllabus data (${{ steps.date.outputs.date }})
           branch: update_${{ steps.date.outputs.date }}
           author: GitHub Action <action@github.com>
@@ -34,4 +35,4 @@ jobs:
             update csv: ${{ steps.date.outputs.date }}
 
           labels: automated pr
-          # delete-branch: true
+          delete-branch: true


### PR DESCRIPTION
ref: #9, https://github.com/peter-evans/create-pull-request/issues/970#issuecomment-950458481
scheduled workflowの結果取得した`syllabus/`を`gh-pages`ブランチにPRするように変更した。