### PR TITLE
kdb もどきのブランチ名を修正

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -15,7 +15,7 @@ function _get_nendo() {
 # Get the file name of the latest syllabus data
 function _get_latest_csv() {
   curl -s -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/${ALTKDB_REPO}/git/trees/master?recursive=1" |
+    "https://api.github.com/repos/${ALTKDB_REPO}/git/trees/main?recursive=1" |
     tac | grep -m1 '"path": .*/csv/kdb-.*csv"' | awk -F '"' '$0=$4'
 }
 
@@ -35,7 +35,7 @@ function _get_code_list() {
   fi
 
   echo "[urls]:" >&2
-  curl -sL "https://github.com/${ALTKDB_REPO}/raw/master/${latest_csv}" |
+  curl -sL "https://github.com/${ALTKDB_REPO}/raw/main/${latest_csv}" |
     awk -F '[,"]' 'NR > 1 && $2 != "" {
       print "https://kdb.tsukuba.ac.jp/syllabi/"y"/"$2"/jpn/"
     }' y="$nendo"


### PR DESCRIPTION
fix: #103 
`download.sh` にて参照されている Make-IT-TSUKUBA/alternative-tsukuba-kdb のデフォルトブランチが master → main に変更されたため、スクリプトを修正しました。

直近の Syllabus scheduled update の workflow を見てみると、この参照が間違っているため、本来取得すべきシラバスのデータではなく、不可思議なページがクロールされてしまっています。
https://github.com/Make-IT-TSUKUBA/alternative-tsukuba-syllabus/actions/runs/8308661398/job/22739139374
